### PR TITLE
Feature: Read from files, write to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ Currently produces same output as `xxd` (with no arguments) when tested on the `
 
 Functional help page printed on `zzd --help` or when passed malformed arguments.  
 
-Currently disregards the user's selected output file and uses stdout instead.  
-
 ## Next Steps
 
-- Allow optional output to files  
 - Handle invalid arguments (e.g. column length must be >0)  
 - Investigate exactly which heap allocations are required for the input/output reader initialization  
+- Add color?

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Currently produces same output as `xxd` (with no arguments) when tested on the `
 
 Functional help page printed on `zzd --help` or when passed malformed arguments.  
 
-Currently disregards the user's selected input and output files and uses stdin and stdout instead.  
+Currently disregards the user's selected output file and uses stdout instead.  
 
 ## Next Steps
 
-- Allow optional input from files  
 - Allow optional output to files  
 - Handle invalid arguments (e.g. column length must be >0)  
+- Investigate exactly which heap allocations are required for the input/output reader initialization  


### PR DESCRIPTION
Finally allows reading/writing from/to files.  
I've noted in the README and a commit message that I need to investigate the method I use to accomplish this.  
If I don't heap allocate several of the intermediate steps in generating the AnyReader that I need to return, I get runtime errors sometimes stating that files aren't open for reading/writing. Some sort of race condition that I don't understand is occurring.  

Note that these heap allocations are done with an arena allocator. This is because I never need to free one before the others anyways, and this saves me holding a bunch of different pointers for the sole purpose of calling free() on them.  